### PR TITLE
Use extracts to present the whole article intro, instead of search result snippets

### DIFF
--- a/src/wikipedia.rs
+++ b/src/wikipedia.rs
@@ -15,6 +15,7 @@ use crate::{
 pub struct SearchResult {
     pub title: String,
     pub extract: String,
+    pub index: i32,
 }
 
 
@@ -64,7 +65,11 @@ pub fn get_wikipedia_query(
     };
 
     match query_response {
-        Some(response) => Ok(response.query.pages.values().cloned().collect()),
+        Some(response) => {
+            let mut sorted_response: Vec<SearchResult> = response.query.pages.values().cloned().collect();
+            sorted_response.sort_by(|a, b| a.index.cmp(&b.index));
+            return Ok(sorted_response);
+        }
         None => Err("Could not get the query".into()),
     }
 }


### PR DESCRIPTION
Note that this will break the formatting that highlights the search terms. I'm still looking at a decent way to do that in the API. Ultimately I think I'll need to do some light HTML parsing to pick them out, which we might want anyway since paragraph formatting is missing in the 'plaintext' that the API returns using this call. 