### PR TITLE
Support terminals that aren't able to report their own dimensions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -251,15 +251,24 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 fn prompt_for_size() -> Result<(u16, u16), std::io::Error> {
-    let mut buffer = String::new();
     eprintln!("Unable to automatically determine console dimensions.");
-    eprint!("Enter number of columns: ");
-    io::stdin().read_line(&mut buffer)?;
-    let width:u16 = buffer.trim_end().parse().unwrap();
-    buffer.clear();
-    eprint!("Enter number of rows: ");
-    io::stdin().read_line(&mut buffer)?;
-    let height:u16 = buffer.trim_end().parse().unwrap();
+    let width = get_dimension("columns");
+    let height = get_dimension("rows");
     return Ok((width, height))
 }
 
+fn get_dimension(dimension_name:&str) -> u16 {
+    let mut buffer = String::new();
+    loop {
+        eprint!("Enter number of {}: ", dimension_name);
+        io::stdin().read_line(&mut buffer).unwrap();
+        match buffer.trim_end().parse::<u16>() {
+            Ok(dimension) => return dimension,
+            Err(_e) => {
+                println!("Invalid input, please enter a positive integer.");
+                buffer.clear();
+                continue;
+            },
+        };
+    };
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,12 +27,13 @@ use tui::layout::Rect;
 use tui::{Terminal, TerminalOptions, Viewport};
 
 const APP_REFRESH_TIME_MILLIS: u64 = 16;
+const APP_DEFAULT_MARGIN: u16 = 2;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Setup terminal
     let mut fixed_size = false;
     let mut size = size()?;
-    let mut margin:u16 = 2;
+    let mut margin:u16 = APP_DEFAULT_MARGIN;
     if size.0 < 1 || size.1 < 1 {
         fixed_size = true;
         size = prompt_for_size()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,9 +32,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Setup terminal
     let mut fixed_size = false;
     let mut size = size()?;
+    let mut margin:u16 = 2;
     if size.0 < 1 || size.1 < 1 {
         fixed_size = true;
         size = prompt_for_size()?;
+        margin = get_dimension("margin size");
     }
 
     enable_raw_mode()?;
@@ -54,7 +56,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         if !app.is_running {
             break;
         }
-        terminal.draw(|f| ui::draw(f, &app))?;
+        terminal.draw(|f| ui::draw(f, &app, margin))?;
 
         if event::poll(Duration::from_millis(APP_REFRESH_TIME_MILLIS))? {
             if let Event::Key(key) = event::read()? {
@@ -260,7 +262,7 @@ fn prompt_for_size() -> Result<(u16, u16), std::io::Error> {
 fn get_dimension(dimension_name:&str) -> u16 {
     let mut buffer = String::new();
     loop {
-        eprint!("Enter number of {}: ", dimension_name);
+        eprint!("Enter {}: ", dimension_name);
         io::stdin().read_line(&mut buffer).unwrap();
         match buffer.trim_end().parse::<u16>() {
             Ok(dimension) => return dimension,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -130,10 +130,10 @@ fn search_box_widget<'a>(
     .block(text_block)
 }
 
-fn draw_search<'a, B: Backend>(frame: &mut Frame<B>, app: &App) {
+pub fn draw<'a, B: Backend>(frame: &mut Frame<B>, app: &App, margin: u16) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .margin(2)
+        .margin(margin)
         .constraints([Constraint::Length(3), Constraint::Min(0)].as_ref())
         .split(frame.size());
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -23,7 +23,7 @@ use tui::{
 
 use substring::Substring;
 
-pub fn draw<'a, B: Backend>(frame: &mut Frame<B>, app: &App) {
+pub fn draw<'a, B: Backend>(frame: &mut Frame<B>, app: &App, margin: u16) {
     let window_area = frame.size();
     frame.render_widget(
         Block::default().style(app.theme.window_background()),
@@ -31,12 +31,12 @@ pub fn draw<'a, B: Backend>(frame: &mut Frame<B>, app: &App) {
     );
     match app.state {
         AppState::Title => draw_title(frame, app),
-        AppState::Search => draw_search(frame, app),
+        AppState::Search => draw_search(frame, app, margin),
         AppState::SearchMenu => draw_menu(frame, app, &app.search_menu),
         AppState::Credit => draw_credit(frame, app),
         AppState::Article => draw_article(frame, app),
         AppState::ArticleMenu => draw_menu(frame, app, &app.article_menu),
-        _ => draw_search(frame, app),
+        _ => draw_search(frame, app, margin),
     }
 }
 
@@ -130,7 +130,7 @@ fn search_box_widget<'a>(
     .block(text_block)
 }
 
-pub fn draw<'a, B: Backend>(frame: &mut Frame<B>, app: &App, margin: u16) {
+pub fn draw_search<'a, B: Backend>(frame: &mut Frame<B>, app: &App, margin: u16) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(margin)


### PR DESCRIPTION
Part of the reason I'm interested in this (awesome) project is for my older dial-up terminals. I have a dialup-to-telnet bridge up that executes _Wik_ as the default "terminal", and access it using Telix on MS-DOS, Terminus on Amiga Workbench 1.3, and I'm working on patching support for my ADM-5 into tui-rs. 

One problem is that these older terminals can't report their own dimensions, resulting in a crash on startup. This PR detects if the reported dimensions are 0, and then prompts the user to enter dimensions manually. It also prompts for a user-settable margin in this case since screen space may be limited. 

Not sure if you'd be interested in merging it, but figured I'd send it over just in case. 